### PR TITLE
Movement config improvements

### DIFF
--- a/samples/common/nRF9160dk_uart_interface/messages.h
+++ b/samples/common/nRF9160dk_uart_interface/messages.h
@@ -10,6 +10,7 @@ enum mesh_uart_msg_type
     STATUS=0x04, // Status of previous command.
     MOVEMENT_REPORTED=0x05, // Movement report from robot.
     CLEAR_TO_MOVE=0x06, // Robots ready to move.
+    MOVEMENT_CONFIG_ACCEPTED=0x07, // Movement configuration accepted by robot.
 };
 
 struct mesh_uart_status_data
@@ -32,7 +33,7 @@ struct mesh_uart_movement_reported_data
     int32_t yaw;
 }__packed;
 
-struct mesh_uart_set_movement_config_data
+struct mesh_uart_movement_config
 {
     uint16_t addr;
     uint32_t time;
@@ -71,7 +72,13 @@ struct mesh_uart_movement_reported_msg
 struct mesh_uart_set_movement_config_msg
 {
     struct mesh_uart_msg_header header;
-    struct mesh_uart_set_movement_config_data data;
+    struct mesh_uart_movement_config data;
+}__packed;
+
+struct mesh_uart_movement_config_accepted_msg
+{
+    struct mesh_uart_msg_header header;
+    struct mesh_uart_movement_config data;
 }__packed;
 
 struct mesh_uart_clear_to_move_msg
@@ -88,4 +95,5 @@ union mesh_uart_msg
     struct mesh_uart_movement_reported_msg movement_reported;
     struct mesh_uart_set_movement_config_msg set_movement_config;
     struct mesh_uart_clear_to_move_msg clear_to_move;
+    struct mesh_uart_movement_config_accepted_msg movement_config_accepted;
 };

--- a/samples/common/nRF9160dk_uart_interface/messages.h
+++ b/samples/common/nRF9160dk_uart_interface/messages.h
@@ -1,38 +1,46 @@
 #pragma once
 #include <stdint.h>
 
-enum peripheral_msg_type
+enum mesh_uart_msg_type
 {
-    HELLO=0x00,
-    SET_MOVEMENT_CONFIG=0x01,
-    SET_LIGHT_CONFIG=0x02,
-    ROBOT_ADDED=0x03,
-    CONFIG_ACK=0x04,
-    MOVEMENT_REPORTED=0x05,
-    CLEAR_TO_MOVE=0x06,
+    HELLO=0x00, // Handshake message.
+    SET_MOVEMENT_CONFIG=0x01, // Set robot movement configuration.
+    SET_LIGHT_CONFIG=0x02, // Set robot light configuration.
+    ROBOT_ADDED=0x03, // Robot added to the network.
+    STATUS=0x04, // Status of previous command.
+    MOVEMENT_REPORTED=0x05, // Movement report from robot.
+    CLEAR_TO_MOVE=0x06, // Robots ready to move.
 };
 
-struct mesh_uart_config_ack_data
+struct mesh_uart_status_data
 {
-    uint64_t addr;
+    int16_t status;
 }__packed;
 
 struct mesh_uart_robot_added_data
 {
-    uint64_t addr;
+    uint8_t mac_address[6]; // 48 bit MAC address.
+    uint16_t mesh_address; // 16 bit address on the mesh network.
 }__packed;
 
 struct mesh_uart_movement_reported_data
 {
-    uint64_t addr;
+    uint16_t addr; // Mesh network address
     int32_t x;
     int32_t y;
     int32_t yaw;
 }__packed;
 
+struct mesh_uart_set_movement_config_data
+{
+    uint16_t addr;
+    uint32_t time;
+    int32_t angle;
+}__packed;
+
 struct mesh_uart_msg_header
 {
-    enum peripheral_msg_type type;
+    enum mesh_uart_msg_type type;
 }__packed;
 
 struct mesh_uart_hello_msg
@@ -47,16 +55,22 @@ struct mesh_uart_robot_added_msg
     struct mesh_uart_robot_added_data data;
 }__packed;
 
-struct mesh_uart_config_ack_msg
+struct mesh_uart_status_msg
 {
     struct mesh_uart_msg_header header;
-    struct mesh_uart_config_ack_data data;
+    struct mesh_uart_status_data data;
 }__packed;
 
 struct mesh_uart_movement_reported_msg
 {
     struct mesh_uart_msg_header header;
     struct mesh_uart_movement_reported_data data;
+}__packed;
+
+struct mesh_uart_set_movement_config_msg
+{
+    struct mesh_uart_msg_header header;
+    struct mesh_uart_set_movement_config_data data;
 }__packed;
 
 struct mesh_uart_clear_to_move_msg
@@ -69,7 +83,8 @@ union mesh_uart_msg
     struct mesh_uart_msg_header header;
     struct mesh_uart_hello_msg hello;
     struct mesh_uart_robot_added_msg robot_added;
-    struct mesh_uart_config_ack_msg config_ack;
+    struct mesh_uart_status_msg status;
     struct mesh_uart_movement_reported_msg movement_reported;
+    struct mesh_uart_set_movement_config_msg set_movement_config;
     struct mesh_uart_clear_to_move_msg clear_to_move;
 };

--- a/samples/common/nRF9160dk_uart_interface/messages.h
+++ b/samples/common/nRF9160dk_uart_interface/messages.h
@@ -19,6 +19,7 @@ struct mesh_uart_status_data
 
 struct mesh_uart_robot_added_data
 {
+    uint64_t addr; // Temporary dummy address. Should be removed once we have decided on an addressing scheme.
     uint8_t mac_address[6]; // 48 bit MAC address.
     uint16_t mesh_address; // 16 bit address on the mesh network.
 }__packed;

--- a/samples/gateway_nRF52840/Kconfig
+++ b/samples/gateway_nRF52840/Kconfig
@@ -22,6 +22,14 @@ config MESH_UART_RX_BUF_COUNT
 	int "UART RX buffer count"
 	default 4
 
+config UART_THREAD_STACK_SIZE
+	int "UART thread stack size"
+	default 2048
+
+config UART_THREAD_PRIORITY
+	int "UART thread priority"
+	default 5
+
 module = APPLICATION_MODULE
 module-str = Application module
 source "subsys/logging/Kconfig.template.log_config"

--- a/samples/gateway_nRF52840/src/model_handler.c
+++ b/samples/gateway_nRF52840/src/model_handler.c
@@ -56,5 +56,6 @@ const struct bt_mesh_comp *model_handler_init(struct bt_mesh_robot_config_cli **
 {
     *config_client = &robot_conf_cli;
     (*config_client)->model = &vendor_models[0];
+    bt_mesh_msg_ack_ctx_init(&(*config_client)->ack_ctx);
     return &comp;
 }

--- a/samples/gateway_nRF52840/src/robot_movement_cli.c
+++ b/samples/gateway_nRF52840/src/robot_movement_cli.c
@@ -13,22 +13,53 @@ LOG_MODULE_REGISTER(MODULE, CONFIG_ROBOT_CONFIG_CLIENT_LOG_LEVEL);
 
 int configure_robot_movement(struct bt_mesh_robot_config_cli *config_client, uint16_t address, struct robot_movement_set_msg msg)
 {
-    struct bt_mesh_msg_ctx ctx;
-}
-
-int send_clear_to_move(struct bt_mesh_robot_config_cli *config_client, uint16_t address)
-{
-    if (!bt_mesh_is_provisioned()){
+    if (!bt_mesh_is_provisioned())
+    {
         LOG_ERR("Device not provisioned");
         return -EAGAIN;
     }
     struct bt_mesh_msg_ctx ctx =
+        {
+            .addr = address,
+            .app_idx = config_client->model->keys[0],
+            .send_ttl = BT_MESH_TTL_DEFAULT,
+            .send_rel = false,
+        };
+
+    if (bt_mesh_msg_ack_ctx_prepare(&config_client->ack_ctx, OP_VND_ROBOT_MOVEMENT_SET_STATUS, address, NULL)){
+        LOG_ERR("Failed to prepare ack ctx");
+        return -EALREADY;
+    }
+
+    BT_MESH_MODEL_BUF_DEFINE(buf, OP_VND_ROBOT_MOVEMENT_SET, sizeof(struct robot_movement_set_msg));
+    bt_mesh_model_msg_init(&buf, OP_VND_ROBOT_MOVEMENT_SET);
+    net_buf_simple_add_be32(&buf, msg.time);
+    net_buf_simple_add_be32(&buf, msg.angle);
+    int err = bt_mesh_model_send(config_client->model, &ctx, &buf, NULL, NULL);
+    if (err)
     {
-        .addr = address,
-        .app_idx = config_client->model->keys[0],
-        .send_ttl = BT_MESH_TTL_DEFAULT,
-        .send_rel = false,
-    };
+        LOG_ERR("Failed to send message (err %d)", err);
+        bt_mesh_msg_ack_ctx_clear(&config_client->ack_ctx);
+        return err;
+    }
+
+    return bt_mesh_msg_ack_ctx_wait(&config_client->ack_ctx, K_MSEC((CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_BASE + 256 * CONFIG_BT_MESH_MOD_ACKD_TIMEOUT_PER_HOP)));
+}
+
+int send_clear_to_move(struct bt_mesh_robot_config_cli *config_client, uint16_t address)
+{
+    if (!bt_mesh_is_provisioned())
+    {
+        LOG_ERR("Device not provisioned");
+        return -EAGAIN;
+    }
+    struct bt_mesh_msg_ctx ctx =
+        {
+            .addr = address,
+            .app_idx = config_client->model->keys[0],
+            .send_ttl = BT_MESH_TTL_DEFAULT,
+            .send_rel = false,
+        };
 
     BT_MESH_MODEL_BUF_DEFINE(buf, OP_VND_ROBOT_CLEAR_TO_MOVE, 0);
     bt_mesh_model_msg_init(&buf, OP_VND_ROBOT_CLEAR_TO_MOVE);
@@ -36,10 +67,25 @@ int send_clear_to_move(struct bt_mesh_robot_config_cli *config_client, uint16_t 
     return bt_mesh_model_send(config_client->model, &ctx, &buf, NULL, NULL);
 }
 
-
 /* Received commands */
 static int handle_robot_movement_done_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
 {
+    LOG_DBG("Movement done status received");
+    return 0;
+}
+
+static int handle_robot_movement_set_status(struct bt_mesh_model *model, struct bt_mesh_msg_ctx *ctx, struct net_buf_simple *buf)
+{
+    LOG_DBG("Movement set status received");
+    struct bt_mesh_robot_config_cli *config_client = model->user_data;
+
+    if (bt_mesh_msg_ack_ctx_match(&config_client->ack_ctx, OP_VND_ROBOT_MOVEMENT_SET_STATUS, ctx->addr, NULL))
+    {
+        bt_mesh_msg_ack_ctx_rx(&config_client->ack_ctx);
+        LOG_DBG("ACK received for movement set message");
+    }
+
+    // TODO: Inform rest of system
     return 0;
 }
 
@@ -52,6 +98,11 @@ const struct bt_mesh_model_op robot_config_cli_ops[] = {
         OP_VND_ROBOT_MOVEMENT_DONE_STATUS,
         sizeof(struct robot_movement_done_status_msg),
         handle_robot_movement_done_status,
+    },
+    {
+        OP_VND_ROBOT_MOVEMENT_SET_STATUS,
+        sizeof(struct robot_movement_set_status_msg),
+        handle_robot_movement_set_status,
     },
     BT_MESH_MODEL_OP_END,
 };

--- a/samples/gateway_nRF52840/src/robot_movement_cli.h
+++ b/samples/gateway_nRF52840/src/robot_movement_cli.h
@@ -18,6 +18,7 @@ struct bt_mesh_robot_config_cli
     struct net_buf_simple pub_msg;
     uint8_t buf[BT_MESH_MODEL_BUF_LEN(OP_VND_ROBOT_CLEAR_TO_MOVE, 0)];
     struct bt_mesh_robot_config_cli_handlers handlers;
+    struct bt_mesh_msg_ack_ctx ack_ctx;
 };
 
 #define BT_MESH_MODEL_VND_ROBOT_CONFIG_CLI(_robot_config_cli)                        \

--- a/samples/gateway_nRF52840/src/uart_handler.c
+++ b/samples/gateway_nRF52840/src/uart_handler.c
@@ -9,9 +9,17 @@
 #include <zephyr/logging/log.h>
 LOG_MODULE_REGISTER(MODULE, CONFIG_UART_MODULE_LOG_LEVEL);
 
+struct uart_thread_msg
+{
+	struct device *uart_dev;
+	struct bt_mesh_robot_config_cli *config_client;
+	union mesh_uart_msg msg;
+};
+K_MSGQ_DEFINE(uart_msg_queue, sizeof(struct uart_thread_msg), 4, 4);
+
 K_MEM_SLAB_DEFINE_STATIC(mesh_uart_rx_slab, CONFIG_MESH_UART_RX_BUF_SIZE, CONFIG_MESH_UART_RX_BUF_COUNT, 4);
 
-static int uart_data_rx_rdy_handler(const struct device* dev, struct uart_event_rx event_data, struct bt_mesh_robot_config_cli *config_client)
+static int uart_data_rx_rdy_handler(const struct device *dev, struct uart_event_rx event_data, struct bt_mesh_robot_config_cli *config_client)
 {
 	static union mesh_uart_msg msg;
 	static size_t current_msg_len = 0; // Length of currently received fragment
@@ -26,6 +34,11 @@ static int uart_data_rx_rdy_handler(const struct device* dev, struct uart_event_
 		return 0; // Header not yet received. Keep waiting for more data.
 	}
 
+	struct uart_thread_msg thread_msg; // Prepare message for message queue
+	thread_msg.uart_dev = dev;
+	thread_msg.config_client = config_client;
+	thread_msg.msg = msg;
+
 	LOG_DBG("Got message with type %d", msg.header.type);
 	switch (msg.header.type)
 	{
@@ -36,17 +49,39 @@ static int uart_data_rx_rdy_handler(const struct device* dev, struct uart_event_
 			return 0; // Message not complete. Keep waiting for more data.
 		}
 		LOG_DBG("UART \"HELLO\" received");
-		uart_tx(dev, (uint8_t*)&msg, sizeof(msg.hello), SYS_FOREVER_US);
+		int err = k_msgq_put(&uart_msg_queue, &thread_msg, K_NO_WAIT);
+		if (err)
+		{
+			LOG_ERR("Failed to enqueue message: Error %d", err);
+		}
 		break;
 	}
-	case CLEAR_TO_MOVE: 
+	case CLEAR_TO_MOVE:
 	{
 		if (current_msg_len < sizeof(msg.clear_to_move))
 		{
 			return 0; // Message not complete. Keep waiting for more data.
 		}
 		LOG_DBG("UART \"CLEAR_TO_MOVE\" received");
-		send_clear_to_move(config_client, BT_MESH_ADDR_ALL_NODES);
+		int err = k_msgq_put(&uart_msg_queue, &thread_msg, K_NO_WAIT);
+		if (err)
+		{
+			LOG_ERR("Failed to enqueue message: Error %d", err);
+		}
+		break;
+	}
+	case SET_MOVEMENT_CONFIG:
+	{
+		if (current_msg_len < sizeof(msg.set_movement_config))
+		{
+			return 0; // Message not complete. Keep waiting for more data.
+		}
+		LOG_DBG("UART \"SET_MOVEMENT_CONFIG\" received");
+		int err = k_msgq_put(&uart_msg_queue, &thread_msg, K_NO_WAIT);
+		if (err)
+		{
+			LOG_ERR("Failed to enqueue message: Error %d", err);
+		}
 		break;
 	}
 	default:
@@ -60,6 +95,40 @@ static int uart_data_rx_rdy_handler(const struct device* dev, struct uart_event_
 	return 0;
 }
 
+static K_SEM_DEFINE(uart_tx_sem, 1, 1);
+static int mesh_uart_send(const struct device *dev, void *data, size_t len, k_timeout_t timeout)
+{
+	int err = k_sem_take(&uart_tx_sem, timeout);
+	if (err)
+	{
+		LOG_ERR("Failed to take semaphore: Error %d", err);
+		return err;
+	}
+	err = uart_tx(dev, data, len, SYS_FOREVER_US);
+	if (err)
+	{
+		LOG_ERR("Failed to send data: Error %d", err);
+		return err;
+	}
+	return 0;
+}
+
+static int mesh_uart_send_status(const struct device *dev, int status, k_timeout_t timeout)
+{
+	static struct mesh_uart_status_msg msg;
+	msg.header.type = STATUS;
+	msg.data.status = status;
+	return mesh_uart_send(dev, &msg, sizeof(msg), timeout);
+}
+
+static int mesh_uart_send_hello(const struct device *dev, uint16_t echo, k_timeout_t timeout)
+{
+	static struct mesh_uart_hello_msg msg;
+	msg.header.type = HELLO;
+	msg.echo = echo;
+	return mesh_uart_send(dev, &msg, sizeof(msg), timeout);
+}
+
 static void uart_callback(const struct device *dev, struct uart_event *event, void *user_data)
 {
 	struct bt_mesh_robot_config_cli *config_client = (struct bt_mesh_robot_config_cli *)user_data;
@@ -68,11 +137,13 @@ static void uart_callback(const struct device *dev, struct uart_event *event, vo
 	case UART_TX_DONE:
 	{
 		LOG_DBG("UART_TX_DONE: Sent %d bytes", event->data.tx.len);
+		k_sem_give(&uart_tx_sem);
 		break;
 	}
 	case UART_TX_ABORTED:
 	{
 		LOG_ERR("UART_TX_ABORTED");
+		k_sem_give(&uart_tx_sem);
 		break;
 	}
 	case UART_RX_RDY:
@@ -122,7 +193,6 @@ static void uart_callback(const struct device *dev, struct uart_event *event, vo
 	}
 }
 
-
 int init_uart(const struct device *uart_dev, struct bt_mesh_robot_config_cli *config_client)
 {
 	int err = 0;
@@ -134,7 +204,7 @@ int init_uart(const struct device *uart_dev, struct bt_mesh_robot_config_cli *co
 	}
 	LOG_DBG("UART device ready");
 
-	err = uart_callback_set(uart_dev, uart_callback, (void*)config_client);
+	err = uart_callback_set(uart_dev, uart_callback, (void *)config_client);
 	if (err)
 	{
 		LOG_ERR("Failed to set UART callback: Error %d", err);
@@ -150,3 +220,61 @@ int init_uart(const struct device *uart_dev, struct bt_mesh_robot_config_cli *co
 	uart_rx_enable(uart_dev, initial_rx_buf, CONFIG_MESH_UART_RX_BUF_SIZE, 1000);
 	return 0;
 }
+
+static int uart_send_generic_ack(const struct device *uart_dev, int status, int32_t timeout)
+{
+	static struct mesh_uart_status_data msg;
+	return uart_tx(uart_dev, &msg, sizeof(msg), timeout);
+}
+
+static void uart_thread_fn(void *arg1, void *arg2, void *arg3)
+{
+	LOG_DBG("Starting UART thread");
+	struct uart_thread_msg thread_msg;
+	while (true)
+	{
+		int err = k_msgq_get(&uart_msg_queue, &thread_msg, K_FOREVER);
+		if (err)
+		{
+			LOG_ERR("Failed to dequeue message: Error %d", err);
+			continue;
+		}
+		switch (thread_msg.msg.header.type)
+		{
+		case HELLO:
+		{
+			mesh_uart_send_hello(thread_msg.uart_dev, thread_msg.msg.hello.echo, K_FOREVER);
+			break;
+		}
+		case CLEAR_TO_MOVE:
+		{
+			err = send_clear_to_move(thread_msg.config_client, BT_MESH_ADDR_ALL_NODES);
+			if (err)
+			{
+				LOG_ERR("Failed to send CLEAR_TO_MOVE: Error %d", err);
+			}
+			break;
+		}
+		case SET_MOVEMENT_CONFIG:
+		{
+			struct robot_movement_set_msg movement_config;
+			movement_config.time = thread_msg.msg.set_movement_config.data.time;
+			movement_config.angle = thread_msg.msg.set_movement_config.data.angle;
+			err = configure_robot_movement(thread_msg.config_client, thread_msg.msg.set_movement_config.data.addr, movement_config);
+			if (err)
+			{
+				LOG_ERR("Failed to set robot movement configuration: Error %d", err);
+			}
+			mesh_uart_send_status(thread_msg.uart_dev, err, K_FOREVER);
+			break;
+		}
+		default:
+		{
+			LOG_ERR("Unknown message type %d", thread_msg.msg.header.type);
+			break;
+		}
+		}
+	}
+}
+
+K_THREAD_DEFINE(uart_thread, CONFIG_UART_THREAD_STACK_SIZE, uart_thread_fn, NULL, NULL, NULL, CONFIG_UART_THREAD_PRIORITY, 0, 0);

--- a/samples/gateway_nRF52840/src/uart_handler.c
+++ b/samples/gateway_nRF52840/src/uart_handler.c
@@ -87,6 +87,7 @@ static int uart_data_rx_rdy_handler(const struct device *dev, struct uart_event_
 	default:
 	{
 		LOG_ERR("Unknown message type %d", msg.header.type);
+		current_msg_len = 0;
 		return -EINVAL;
 	}
 	}

--- a/samples/gateway_nRF52840/src/uart_handler.h
+++ b/samples/gateway_nRF52840/src/uart_handler.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <zephyr/device.h>
 #include "../../common/nRF9160dk_uart_interface/messages.h"
+#include "robot_movement_cli.h"
 
 int init_uart(const struct device *dev, struct bt_mesh_robot_config_cli *config_client);
 

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.c
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.c
@@ -23,6 +23,8 @@ static char *type_to_str(enum mesh_module_event_type type)
         return "MESH_EVT_OP_STATUS";
     case MESH_EVT_MOVEMENT_REPORTED:
         return "MESH_EVT_MOVEMENT_REPORTED";
+    case MESH_EVT_MOVEMENT_CONFIG_ACCEPTED:
+        return "MESH_EVT_MOVEMENT_CONFIG_ACCEPTED";
     default:
         return "UNKNOWN";
     }

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.c
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.c
@@ -19,8 +19,8 @@ static char *type_to_str(enum mesh_module_event_type type)
         return "MESH_EVT_READY";
     case MESH_EVT_ROBOT_ADDED:
         return "MESH_EVT_ROBOT_ADDED";
-    case MESH_EVT_CONFIG_ACK:
-        return "MESH_EVT_CONFIG_ACK";
+    case MESH_EVT_OP_STATUS:
+        return "MESH_EVT_OP_STATUS";
     case MESH_EVT_MOVEMENT_REPORTED:
         return "MESH_EVT_MOVEMENT_REPORTED";
     default:

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.h
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.h
@@ -23,10 +23,10 @@ extern "C" {
 
 
 enum mesh_module_event_type {
-    MESH_EVT_READY,
-	MESH_EVT_ROBOT_ADDED,
+    MESH_EVT_READY, // Mesh module is ready to use.
+	MESH_EVT_ROBOT_ADDED, // Robot added to network.
     MESH_EVT_OP_STATUS, // Status of previous operation.
-    MESH_EVT_MOVEMENT_REPORTED,
+    MESH_EVT_MOVEMENT_REPORTED, // Movement reported by robot.
 };
 
 struct mesh_module_event {

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.h
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.h
@@ -37,7 +37,7 @@ struct mesh_module_event {
         int status; // MESH_EVT_OP_STATUS: Status for previous operation.
         struct mesh_uart_robot_added_data new_robot; // MESH_EVT_ROBOT_ADDED: Data about new robot.
         struct mesh_uart_movement_reported_data movement_reported; // MESH_EVT_MOVEMENT_REPORTED: Data about actual movement reported by robot.
-        struct mesh_uart_set_movement_config_data movement_config; // MESH_EVT_MOVEMENT_CONFIG_ACCEPTED: Movement configuration accepted by robot.
+        struct mesh_uart_movement_config movement_config; // MESH_EVT_MOVEMENT_CONFIG_ACCEPTED: Movement configuration accepted by robot.
     } data;
 };
 

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.h
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.h
@@ -25,7 +25,7 @@ extern "C" {
 enum mesh_module_event_type {
     MESH_EVT_READY,
 	MESH_EVT_ROBOT_ADDED,
-    MESH_EVT_CONFIG_ACK,
+    MESH_EVT_OP_STATUS, // Status of previous operation.
     MESH_EVT_MOVEMENT_REPORTED,
 };
 
@@ -33,7 +33,7 @@ struct mesh_module_event {
     struct app_event_header header;
     enum mesh_module_event_type type;
     union {
-        struct mesh_uart_config_ack_data config_ack;
+        int status;
         struct mesh_uart_robot_added_data new_robot;
         struct mesh_uart_movement_reported_data movement_reported;
     } data;

--- a/samples/gateway_nRF9160/src/events/mesh_module_event.h
+++ b/samples/gateway_nRF9160/src/events/mesh_module_event.h
@@ -27,15 +27,17 @@ enum mesh_module_event_type {
 	MESH_EVT_ROBOT_ADDED, // Robot added to network.
     MESH_EVT_OP_STATUS, // Status of previous operation.
     MESH_EVT_MOVEMENT_REPORTED, // Movement reported by robot.
+    MESH_EVT_MOVEMENT_CONFIG_ACCEPTED, // Movement configuration accepted by robot.
 };
 
 struct mesh_module_event {
     struct app_event_header header;
     enum mesh_module_event_type type;
     union {
-        int status;
-        struct mesh_uart_robot_added_data new_robot;
-        struct mesh_uart_movement_reported_data movement_reported;
+        int status; // MESH_EVT_OP_STATUS: Status for previous operation.
+        struct mesh_uart_robot_added_data new_robot; // MESH_EVT_ROBOT_ADDED: Data about new robot.
+        struct mesh_uart_movement_reported_data movement_reported; // MESH_EVT_MOVEMENT_REPORTED: Data about actual movement reported by robot.
+        struct mesh_uart_set_movement_config_data movement_config; // MESH_EVT_MOVEMENT_CONFIG_ACCEPTED: Movement configuration accepted by robot.
     } data;
 };
 

--- a/samples/gateway_nRF9160/src/modules/cloud_module.c
+++ b/samples/gateway_nRF9160/src/modules/cloud_module.c
@@ -22,10 +22,10 @@
 #define CLOUD_MODULE_LOG_LEVEL 4
 LOG_MODULE_REGISTER(MODULE, CLOUD_MODULE_LOG_LEVEL);
 
-#define TOPIC_UPDATE_DELTA "$aws/things/robot_wars_gateway/shadow/update/delta"
-#define TOPIC_GET_ACCEPTED "$aws/things/robot_wars_gateway/shadow/get/accepted"
-#define TOPIC_UPDATE_ACCEPTED "$aws/things/robot_wars_gateway/shadow/update/accepted"
-#define TOPIC_UPDATE_REJECTED "$aws/things/robot_wars_gateway/shadow/update/rejected"
+#define TOPIC_UPDATE_DELTA "$aws/things/" CONFIG_AWS_IOT_CLIENT_ID_STATIC "/shadow/update/delta"
+#define TOPIC_GET_ACCEPTED "$aws/things/" CONFIG_AWS_IOT_CLIENT_ID_STATIC "/shadow/get/accepted"
+#define TOPIC_UPDATE_ACCEPTED "$aws/things/" CONFIG_AWS_IOT_CLIENT_ID_STATIC "/shadow/update/accepted"
+#define TOPIC_UPDATE_REJECTED "$aws/things/" CONFIG_AWS_IOT_CLIENT_ID_STATIC "/shadow/update/rejected"
 
 QOS_MESSAGE_TYPES_REGISTER(CLOUD_SHADOW_UPDATE);
 QOS_MESSAGE_TYPES_REGISTER(CLOUD_SHADOW_CLEAR);

--- a/samples/gateway_nRF9160/src/modules/mesh_module.c
+++ b/samples/gateway_nRF9160/src/modules/mesh_module.c
@@ -209,6 +209,17 @@ static int uart_data_rx_rdy_handler(struct uart_event_rx event_data)
 		LOG_DBG("UART \"MOVEMENT_REPORTED\" received");
 		break;
 	}
+	case MOVEMENT_CONFIG_ACCEPTED: {
+		if (current_msg_len < sizeof(msg.movement_config_accepted))
+		{
+			return 0; // Message not complete. Keep waiting for more data.
+		}
+		struct mesh_module_event *evt = new_mesh_module_event();
+		evt->type = MESH_EVT_MOVEMENT_CONFIG_ACCEPTED;
+		evt->data.movement_config = msg.movement_config_accepted.data;
+		APP_EVENT_SUBMIT(evt);
+		break;
+	}
 	default:
 	{
 		LOG_ERR("Unknown message type %d", msg.header.type);
@@ -338,7 +349,7 @@ static void on_state_mesh_ready(struct mesh_msg_data *msg)
 			uart_send_clear_to_move(K_FOREVER);
 			break;
 		}
-		case ROBOT_EVT_CONFIGURE: {
+		case ROBOT_EVT_MOVEMENT_CONFIGURE: {
 			LOG_DBG("Configuring robot");
 			uint16_t addr = msg->module.robot.data.robot.addr;
 			uint32_t time = msg->module.robot.data.robot.cfg->drive_time;

--- a/samples/gateway_nRF9160/src/modules/mesh_module.c
+++ b/samples/gateway_nRF9160/src/modules/mesh_module.c
@@ -223,9 +223,11 @@ static int uart_data_rx_rdy_handler(struct uart_event_rx event_data)
 	default:
 	{
 		LOG_ERR("Unknown message type %d", msg.header.type);
+		current_msg_len = 0;
 		return -EINVAL;
 	}
 	}
+	current_msg_len = 0;
 
 	return 0;
 }

--- a/samples/gateway_nRF9160/src/modules/robot_module.c
+++ b/samples/gateway_nRF9160/src/modules/robot_module.c
@@ -730,9 +730,9 @@ static void on_state_cloud_connected(struct robot_msg_data *msg)
 		report_add_robot(msg->module.mesh.data.new_robot.addr);
 	}
 
-	if (IS_EVENT(msg, mesh, MESH_EVT_CONFIG_ACK)) {
-		report_robot_movement_config(msg->module.mesh.data.config_ack.addr); 
-		set_state_configured(msg->module.mesh.data.config_ack.addr); 
+	if (IS_EVENT(msg, mesh, MESH_EVT_MOVEMENT_CONFIG_ACCEPTED)) {
+		report_robot_movement_config(msg->module.mesh.data.movement_config.addr); 
+		set_state_configured(msg->module.mesh.data.movement_config.addr); 
 	}
 
 	if (IS_EVENT(msg, mesh, MESH_EVT_MOVEMENT_REPORTED)) {


### PR DESCRIPTION
Allows the mesh module to configure a robot when the robot module sends a ROBOT_EVT_MOVEMENT_CONFIGURE event.
Also establishes a pattern for dealing with mesh operations that require acknowledgement.