### PR TITLE
Add support for development configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 \build
 .vscode
+dev_options.conf

--- a/samples/gateway_nRF52840/CMakeLists.txt
+++ b/samples/gateway_nRF52840/CMakeLists.txt
@@ -6,6 +6,11 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+    message(WARNING "Using dev_options.conf. Ensure any critical settings are moved to prj.conf before committing to source control.")
+    list(APPEND CONF_FILE "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_bot)
 

--- a/samples/gateway_nRF9160/CMakeLists.txt
+++ b/samples/gateway_nRF9160/CMakeLists.txt
@@ -6,8 +6,14 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+    message(WARNING "Using dev_options.conf. Ensure any critical settings are moved to prj.conf before committing to source control.")
+    list(APPEND CONF_FILE "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(gateway)
+
 
 # Include application application event headers
 zephyr_library_include_directories(src/events)

--- a/samples/mesh_bot/CMakeLists.txt
+++ b/samples/mesh_bot/CMakeLists.txt
@@ -6,6 +6,11 @@
 
 cmake_minimum_required(VERSION 3.20.0)
 
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+    message(WARNING "Using dev_options.conf. Ensure any critical settings are moved to prj.conf before committing to source control.")
+    list(APPEND CONF_FILE "${CMAKE_CURRENT_SOURCE_DIR}/dev_options.conf")
+endif()
+
 find_package(Zephyr REQUIRED HINTS $ENV{ZEPHYR_BASE})
 project(mesh_bot)
 


### PR DESCRIPTION
Checks for the existence of a file called dev_options.conf and adds it
to the list of KConfig files. The file is ignored by
git, and should primarily serve to set local debug
and logging configurations.

Signed-off-by: Halvor Bjørstad <43417915+Riphiphip@users.noreply.github.com>